### PR TITLE
Github Actionsを修正

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - feature/ci-test
+      - 'feature/marp/**'
 
 permissions:
   contents: read

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - feature/git
+      - feature/ci-test
 
 permissions:
   contents: read
@@ -28,7 +28,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Setup Packages
-        run: sudo apt-get update & sudo apt-get install jq npm fonts-noto
+        run: sudo apt update && sudo apt install jq npm fonts-noto
 
       - name: Install Marp CLI
         run: npm install -g @marp-team/marp-cli


### PR DESCRIPTION
Github Actionsが頻繁に落ちるので、修正した
このブランチのCIも落ちているが、feature/ci-testからのデプロイが拒否されているだけでビルドには成功しているのでOKです