### PR TITLE
ファイル単位でLintを無効にできるようにした

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -1,6 +1,8 @@
 {
   "plugins": {},
-  "filters": {},
+  "filters": {
+    "comments": true
+  },
   "rules": {
     "@proofdict/proofdict": {
       "dictURL": "https://jigintern.github.io/proof-dictionary/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@proofdict/textlint-rule-proofdict": "^3.1.2",
         "textlint": "^14.0.4",
         "textlint-filter-rule-allowlist": "^4.0.0",
+        "textlint-filter-rule-comments": "^1.2.2",
         "textlint-rule-no-todo": "^2.0.1",
         "textlint-rule-preset-ja-technical-writing": "^10.0.1",
         "textlint-rule-prh": "^6.0.0",
@@ -4438,6 +4439,14 @@
     "node_modules/textlint-filter-rule-allowlist/node_modules/@textlint/ast-node-types": {
       "version": "12.6.1",
       "license": "MIT"
+    },
+    "node_modules/textlint-filter-rule-comments": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/textlint-filter-rule-comments/-/textlint-filter-rule-comments-1.2.2.tgz",
+      "integrity": "sha512-AtyxreCPb3Hq/bd6Qd6szY1OGgnW34LOjQXAHzE8NoXbTUudQqALPdRe+hvRsf81rnmGLxBiCUXZbnbpIseFyw==",
+      "peerDependencies": {
+        "textlint": ">=6.8.0"
+      }
     },
     "node_modules/textlint-rule-helper": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@proofdict/textlint-rule-proofdict": "^3.1.2",
     "textlint": "^14.0.4",
     "textlint-filter-rule-allowlist": "^4.0.0",
+    "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.1",
     "textlint-rule-preset-ja-technical-writing": "^10.0.1",
     "textlint-rule-prh": "^6.0.0",


### PR DESCRIPTION
スライドで句読点を使わないため無効にしたい
コメントでlintの有効無効を制御できます。

`<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->  `